### PR TITLE
Fix jsonConfig schema compliance

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -132,7 +132,6 @@
         },
         "pollingRequests": {
           "type": "table",
-          "attr": "pollingRequests",
           "label": "pollingRequests",
           "help": "pollingRequests_help",
           "xs": 12,
@@ -152,9 +151,18 @@
               "attr": "id",
               "label": "dataPoint",
               "options": [
-                { "value": "getStatus", "label": "getStatus" },
-                { "value": "getCapabilities", "label": "getCapabilities" },
-                { "value": "getPowerUsage", "label": "getPowerUsage" }
+                {
+                  "value": "getStatus",
+                  "label": "getStatus"
+                },
+                {
+                  "value": "getCapabilities",
+                  "label": "getCapabilities"
+                },
+                {
+                  "value": "getPowerUsage",
+                  "label": "getPowerUsage"
+                }
               ]
             },
             {


### PR DESCRIPTION
## Summary
- remove the unsupported attr binding from the pollingRequests table definition to match the current jsonConfig schema
- reformat select options for readability after regenerating the JSON structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7d22eaa48325bd6057ed8011b511