### PR TITLE
Ignore invalid humidity setpoint values from bridge

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -276,7 +276,7 @@ class MideaSerialBridge extends EventEmitter {
 
     if (status.humiditySetpoint !== undefined) {
       const parsed = Number(status.humiditySetpoint);
-      if (!Number.isNaN(parsed)) {
+      if (!Number.isNaN(parsed) && parsed >= 35 && parsed <= 85) {
         mapped.humiditySetpoint = parsed;
       }
     }


### PR DESCRIPTION
## Summary
- ignore humidity setpoint values outside the supported range when mapping bridge status to adapter states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dda510db688325bcc548d33d996c0f