### PR TITLE
Ensure JSON commands update states when responses omit values

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -162,7 +162,23 @@ class MideaSerialBridge extends EventEmitter {
 
     const payload = this._applyBeepPreference({ ...command });
     const status = await this.device.setStatus(payload);
-    return this._handleStatus(status);
+    const mapped = this._handleStatus(status);
+
+    if (payload && typeof payload === 'object') {
+      for (const [property, value] of Object.entries(payload)) {
+        if (mapped[property] !== undefined) {
+          continue;
+        }
+
+        const fallback = this._fallbackValue(property, value);
+        if (fallback !== undefined) {
+          mapped[property] = fallback;
+          this.statusCache[property] = fallback;
+        }
+      }
+    }
+
+    return mapped;
   }
 
   _bindDeviceEvents() {


### PR DESCRIPTION
## Summary
- populate fallback datapoint values for JSON commands when the device response omits them so adapter states stay in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de2834726c8325a258bdfb504d863a