### PR TITLE
Clamp numeric state writes to datapoint bounds

### DIFF
--- a/main.js
+++ b/main.js
@@ -1182,7 +1182,14 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       if (Number.isNaN(parsed)) {
         throw new Error(`Invalid numeric value ${value}`);
       }
-      return parsed;
+      let normalized = parsed;
+      if (typeof datapoint.min === 'number' && normalized < datapoint.min) {
+        normalized = datapoint.min;
+      }
+      if (typeof datapoint.max === 'number' && normalized > datapoint.max) {
+        normalized = datapoint.max;
+      }
+      return normalized;
     }
 
     if (datapoint.type === 'string') {


### PR DESCRIPTION
## Summary
- clamp numeric write values to datapoint min/max before forwarding commands to the bridge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de383419cc8325a254d5eee1778cdf