### PR TITLE
Allow fixed fan speed command

### DIFF
--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -225,7 +225,8 @@ module.exports = class extends EventEmitter {
         silent: 20,
         low: 40,
         medium: 60,
-        high: 80
+        high: 80,
+        fixed: 101
       };
 
       for (const property in properties) {
@@ -243,7 +244,7 @@ module.exports = class extends EventEmitter {
               }
             }
             if (typeof properties[property] === 'string' && !fanSpeed[properties[property]]) {
-              return reject(new errors.OutOfRangeError('fanSpeed must be one of: auto, silent, low, medium or high'));
+              return reject(new errors.OutOfRangeError('fanSpeed must be one of: auto, silent, low, medium, high or fixed'));
             }
 
             logger.debug(`AC.setStatus: Set fan speed to ${typeof properties[property] === 'number' ? properties[property] : fanSpeed[properties[property]]}`);


### PR DESCRIPTION
## Summary
- allow the serial bridge to translate the fixed fan speed command to the native value expected by the device
- update the validation error message to list "fixed" as a supported fan speed option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de53abd10c832586177114869d5536